### PR TITLE
Resolved issue where exlude files/folders options where ignored

### DIFF
--- a/src/Handler/AbstractHandler.php
+++ b/src/Handler/AbstractHandler.php
@@ -20,8 +20,9 @@ abstract class AbstractHandler
 
     /**
      * AbstractHandler constructor.
+     *
      * @param Package $package
-     * @param array $options
+     * @param array   $options
      */
     public function __construct(Package $package, array $options)
     {
@@ -34,9 +35,10 @@ abstract class AbstractHandler
      */
     protected function getExcludedDirs()
     {
-        if(!isset($this->options['excludes']['dirs'])) {
+        if (!isset($this->options['excludes']['dirs'])) {
             return [];
         }
+
         return $this->options['excludes']['dirs'];
     }
 
@@ -45,62 +47,56 @@ abstract class AbstractHandler
      */
     protected function getExcludedFiles()
     {
-        if(!isset($this->options['excludes']['files'])) {
+        if (!isset($this->options['excludes']['files'])) {
             return [];
         }
+
         return $this->options['excludes']['files'];
     }
 
     /**
      * @param array $excludeDirs
      * @param array $excludeFiles
+     *
      * @return array
      */
-    protected function getFilesWithExcludes($excludeDirs, $excludeFiles = [])
+    protected function getFilesWithExcludes($excludeDirs, $excludeFiles = [], $onlyFiles = false)
     {
         $excludeFiles = array_merge($this->getExcludedFiles(), $excludeFiles);
+        $files        = [];
+        $finder       = new Finder();
 
-        $files = [];
-        $finder = new Finder();
-        $finder->in($this->package->getDir())->exclude($excludeDirs)->ignoreVCS(false)->ignoreDotFiles(false);
+        $finder->in($this->package->getDir())->ignoreVCS(false)->ignoreDotFiles(false);
+        if ($onlyFiles) {
+            $finder->files();
+        } else {
+            $finder->exclude($excludeDirs);
+        }
+
         foreach (iterator_to_array($finder, false) as $file) {
             if (in_array($file->getRelativePathname(), $excludeFiles)) {
                 continue;
             }
-            if($this->shouldIgnore($file)) {
+            if ($this->shouldIgnore($file)) {
                 continue;
             }
             $files[] = $file->getRealPath();
         }
-        return $files;
-    }
 
-    /**
-     * @return array
-     */
-    protected function getFilesFromDir()
-    {
-        $files = [];
-        $finder = new Finder();
-        $finder->in($this->package->getDir())->ignoreVCS(false)->ignoreDotFiles(false)->files();
-        foreach (iterator_to_array($finder, false) as $file) {
-            if($this->shouldIgnore($file)) {
-                continue;
-            }
-            $files[] = $file->getRealPath();
-        }
         return $files;
     }
 
     /**
      * @param SplFileInfo $file
+     *
      * @return bool
      */
     protected function shouldIgnore(SplFileInfo $file)
     {
-        if($file->getExtension() === 'php') {
+        if ($file->getExtension() === 'php') {
             return true;
         }
+
         return false;
     }
 }

--- a/src/Handler/DefaultHandler.php
+++ b/src/Handler/DefaultHandler.php
@@ -10,30 +10,23 @@ class DefaultHandler extends AbstractHandler implements HandlerInterface
     public function getFilesToRemove()
     {
         // get excludes from autoload mapping
-        $excludeDirs  = [];
-        $excludeFiles = [];
         $psrMapped    = [];
-
-        if(isset($this->options['excludes']['dirs'])) {
-            $excludeDirs = $this->options['excludes']['dirs'];
-        }
-        if(isset($this->options['excludes']['files'])) {
-            $excludeFiles = $this->options['excludes']['files'];
-        }
-
+        $excludeDirs  = $this->getExcludedDirs();
+        $excludeFiles = $this->getExcludedFiles();
         $autoloadData = $this->package->getAutoload();
+
         if (isset($autoloadData['psr-0'])) {
-            foreach($autoloadData['psr-0'] as $namespace => $dir) {
-                if(empty($dir)) {
-                    return $this->getFilesFromDir();
+            foreach ($autoloadData['psr-0'] as $namespace => $dir) {
+                if (empty($dir)) {
+                    return $this->getFilesWithExcludes($excludeDirs, $excludeFiles, true);
                 }
             }
             $psrMapped += $autoloadData['psr-0'];
         }
         if (isset($autoloadData['psr-4'])) {
-            foreach($autoloadData['psr-4'] as $namespace => $dir) {
-                if(empty($dir)) {
-                    return $this->getFilesFromDir();
+            foreach ($autoloadData['psr-4'] as $namespace => $dir) {
+                if (empty($dir)) {
+                    return $this->getFilesWithExcludes($excludeDirs, $excludeFiles, true);
                 }
             }
             $psrMapped += $autoloadData['psr-4'];

--- a/src/Handler/SymfonyBundleHandler.php
+++ b/src/Handler/SymfonyBundleHandler.php
@@ -11,25 +11,26 @@ class SymfonyBundleHandler extends AbstractHandler implements HandlerInterface
      */
     public function getFilesToRemove()
     {
-        $excludeDirs = [];
-        $excludeFiles = [];
-        $finder = new Finder();
+        $excludeDirs  = $this->getExcludedDirs();
+        $excludeFiles = $this->getExcludedFiles();
+        $finder       = new Finder();
+
         foreach ($finder->in($this->package->getDir())->depth(0) as $file) {
-            if($file->isDir()) {
-                if(in_array($file->getRelativePathname(), ['Tests'])) {
+            if ($file->isDir()) {
+                if (in_array($file->getRelativePathname(), ['Tests'])) {
                     continue;
                 }
                 if (in_array($file->getRelativePathname(), $this->getExcludedDirs())) {
                     continue;
                 }
                 $excludeDirs[] = $file->getRelativePathname();
-            }
-            elseif($file->isFile()) {
-                if($file->getExtension() === 'php') {
+            } elseif ($file->isFile()) {
+                if ($file->getExtension() === 'php') {
                     $excludeFiles[] = $file->getRelativePathname();
                 }
             }
         }
+
         return $this->getFilesWithExcludes($excludeDirs, $excludeFiles);
     }
 


### PR DESCRIPTION
The exlude files and folders options in the options.json file was
ignore in multiple instances. This update solves this and you should
be able to exlude files and folders in all packages.

- SymfonyBundleHandler now checks for exluded files and folders.
- DefaultHandler now checks for exluded files and folders if the
detected autoloading type is psr-0 or psr-4.
- Some minor code formatting.